### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "lint": "eslint cli test",
         "commands_md": "./help_to_md.sh"
     },
+    files: [],
     "bin": {
         "apify": "src/bin.js"
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "lint": "eslint cli test",
         "commands_md": "./help_to_md.sh"
     },
-    files: [],
+    "files": [],
     "bin": {
         "apify": "src/bin.js"
     },


### PR DESCRIPTION
#30 
Fixing 
`Error Plugin: apify-cli: files attribute must be specified in <...>. /node_modules/apify-cli/package.json`

Caused by oclif/config v1.6.20
[](https://github.com/oclif/config/compare/v1.6.19...v1.6.20)