### PR TITLE
increased nodeJs default header size.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ install:
     - npm install
 node_js:
   - "10"
-  - "9"
-  - "8"
+  - "12"
 script:
   - npm run lint
   - npm install

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -75,7 +75,7 @@ class RunCommand extends ApifyCommand {
             warning('You are not logged in with your Apify Account. Some features like Apify Proxy will not work. Call "apify login" to fix that.');
         }
 
-        await execWithLog(getNpmCmd(), ['start'], { env });
+        await execWithLog(getNpmCmd(), ['start'], { env, NODE_OPTIONS: '--max-http-header-size=80000' });
     }
 }
 

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -75,6 +75,10 @@ class RunCommand extends ApifyCommand {
             warning('You are not logged in with your Apify Account. Some features like Apify Proxy will not work. Call "apify login" to fix that.');
         }
 
+        // --max-http-header-size=80000
+        // Increases default size of headers. The original limit was 80kb, but from node 10+ they decided to lower it to 8kb.
+        // However they did not think about all the sites there with large headers,
+        // so we put back the old limit of 80kb, which seems to work just fine.
         await execWithLog(getNpmCmd(), ['start'], { env, NODE_OPTIONS: '--max-http-header-size=80000' });
     }
 }

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -70,6 +70,7 @@ class RunCommand extends ApifyCommand {
         }
         // NOTE: User can overwrite env vars
         const env = Object.assign(localEnvVars, process.env);
+        env.NODE_OPTIONS = env.NODE_OPTIONS ? `${env.NODE_OPTIONS} --max-http-header-size=80000` : '--max-http-header-size=80000';
 
         if (!userId) {
             warning('You are not logged in with your Apify Account. Some features like Apify Proxy will not work. Call "apify login" to fix that.');
@@ -79,7 +80,7 @@ class RunCommand extends ApifyCommand {
         // Increases default size of headers. The original limit was 80kb, but from node 10+ they decided to lower it to 8kb.
         // However they did not think about all the sites there with large headers,
         // so we put back the old limit of 80kb, which seems to work just fine.
-        await execWithLog(getNpmCmd(), ['start'], { env, NODE_OPTIONS: '--max-http-header-size=80000' });
+        await execWithLog(getNpmCmd(), ['start'], { env });
     }
 }
 


### PR DESCRIPTION
This should pass the  --max-http-header-size=80000 to the nodeJs process. @drobnikj not sure if I put it on the right place.