### PR TITLE
Readme links fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ DESCRIPTION
   takes input for the actor from the default local key-value store by default.
 ```
 
-_See code: [src/commands/call.js](https://github.com/apifytech/apify-cli/blob/v0.5.0/src/commands/call.js)_
+_See code: [src/commands/call.js](https://github.com/apifytech/apify-cli/blob/master/src/commands/call.js)_
 
 ## `apify create [ACTORNAME]`
 
@@ -269,7 +269,7 @@ OPTIONS
       Boilerplate template for the actor. If not provided, the command will prompt for it.
 ```
 
-_See code: [src/commands/create.js](https://github.com/apifytech/apify-cli/blob/v0.5.0/src/commands/create.js)_
+_See code: [src/commands/create.js](https://github.com/apifytech/apify-cli/blob/master/src/commands/create.js)_
 
 ## `apify info`
 
@@ -283,7 +283,7 @@ DESCRIPTION
   The information is printed to the console.
 ```
 
-_See code: [src/commands/info.js](https://github.com/apifytech/apify-cli/blob/v0.5.0/src/commands/info.js)_
+_See code: [src/commands/info.js](https://github.com/apifytech/apify-cli/blob/master/src/commands/info.js)_
 
 ## `apify init [ACTORNAME]`
 
@@ -303,7 +303,7 @@ DESCRIPTION
   WARNING: The directory at "apify_storage" will be overwritten if it already exists.
 ```
 
-_See code: [src/commands/init.js](https://github.com/apifytech/apify-cli/blob/v0.5.0/src/commands/init.js)_
+_See code: [src/commands/init.js](https://github.com/apifytech/apify-cli/blob/master/src/commands/init.js)_
 
 ## `apify login`
 
@@ -321,7 +321,7 @@ DESCRIPTION
   "apify" commands. To log out, call "apify logout".
 ```
 
-_See code: [src/commands/login.js](https://github.com/apifytech/apify-cli/blob/v0.5.0/src/commands/login.js)_
+_See code: [src/commands/login.js](https://github.com/apifytech/apify-cli/blob/master/src/commands/login.js)_
 
 ## `apify logout`
 
@@ -336,7 +336,7 @@ DESCRIPTION
   call "apify login".
 ```
 
-_See code: [src/commands/logout.js](https://github.com/apifytech/apify-cli/blob/v0.5.0/src/commands/logout.js)_
+_See code: [src/commands/logout.js](https://github.com/apifytech/apify-cli/blob/master/src/commands/logout.js)_
 
 ## `apify push [ACTORID]`
 
@@ -371,7 +371,7 @@ DESCRIPTION
   WARNING: If the target actor already exists in your Apify account, it will be overwritten!
 ```
 
-_See code: [src/commands/push.js](https://github.com/apifytech/apify-cli/blob/v0.5.0/src/commands/push.js)_
+_See code: [src/commands/push.js](https://github.com/apifytech/apify-cli/blob/master/src/commands/push.js)_
 
 ## `apify run`
 
@@ -401,7 +401,7 @@ DESCRIPTION
   can set up your own main file or environment variables by changing it.
 ```
 
-_See code: [src/commands/run.js](https://github.com/apifytech/apify-cli/blob/v0.5.0/src/commands/run.js)_
+_See code: [src/commands/run.js](https://github.com/apifytech/apify-cli/blob/master/src/commands/run.js)_
 
 ## `apify secrets`
 
@@ -427,7 +427,7 @@ DESCRIPTION
   of the actor.
 ```
 
-_See code: [src/commands/secrets/index.js](https://github.com/apifytech/apify-cli/blob/v0.5.0/src/commands/secrets/index.js)_
+_See code: [src/commands/secrets/index.js](https://github.com/apifytech/apify-cli/blob/masster/src/commands/secrets/index.js)_
 
 ## `apify secrets:add NAME VALUE`
 
@@ -445,7 +445,7 @@ DESCRIPTION
   The secrets are stored to a file at ~/.apify
 ```
 
-_See code: [src/commands/secrets/add.js](https://github.com/apifytech/apify-cli/blob/v0.5.0/src/commands/secrets/add.js)_
+_See code: [src/commands/secrets/add.js](https://github.com/apifytech/apify-cli/blob/master/src/commands/secrets/add.js)_
 
 ## `apify secrets:rm NAME`
 
@@ -459,7 +459,7 @@ ARGUMENTS
   NAME  Name of the secret
 ```
 
-_See code: [src/commands/secrets/rm.js](https://github.com/apifytech/apify-cli/blob/v0.5.0/src/commands/secrets/rm.js)_
+_See code: [src/commands/secrets/rm.js](https://github.com/apifytech/apify-cli/blob/master/src/commands/secrets/rm.js)_
 
 ## `apify vis [PATH]`
 
@@ -473,5 +473,5 @@ ARGUMENTS
   PATH  Optional path to your INPUT_SCHEMA.json file. If not provided ./INPUT_SCHEMA.json is used.
 ```
 
-_See code: [src/commands/vis.js](https://github.com/apifytech/apify-cli/blob/v0.5.0/src/commands/vis.js)_
+_See code: [src/commands/vis.js](https://github.com/apifytech/apify-cli/blob/master/src/commands/vis.js)_
 <!-- commandsstop -->


### PR DESCRIPTION
It just fixes source code links to point to master branch instead of version 0.5.0 (now links on https://apify.com/docs/cli are broken).